### PR TITLE
Remove support for GLV point multiplication

### DIFF
--- a/bls377/g1.go
+++ b/bls377/g1.go
@@ -37,7 +37,6 @@ limitations under the License.
 // Most algos for points operations are taken from http://hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html
 
 import (
-	"math/big"
 	"runtime"
 
 	"github.com/consensys/gurvy/bls377/fp"
@@ -484,113 +483,6 @@ func (p *G1Jac) Double() *G1Jac {
 	p.Y.SubAssign(&YYYY)
 
 	return p
-}
-
-// queryNthBit returns the i-th bit of s
-func queryNthBit(s fr.Element, i int) uint64 {
-	limb := i / 64
-	offset := i % 64
-	b := (s[limb] >> offset) & 1
-	return b
-}
-
-// doubleandadd algo for exponentiation
-// n=number of bits of the scalar s
-func (p *G1Jac) doubleandadd(curve *Curve, a *G1Affine, s fr.Element, n int) *G1Jac {
-
-	var res G1Jac
-	res.Set(&curve.g1Infinity)
-
-	for i := n - 1; i >= 0; i-- {
-		b := queryNthBit(s, i)
-		res.Double()
-		if b == 1 {
-			res.AddMixed(a)
-		}
-	}
-	p.Set(&res)
-	return &res
-}
-
-// ScalarMulEndo performs scalar multiplication
-// using the endo phi(p=(x,y))=(ux,y) where u is a 3rd root of 1,
-// phi(P) = lambda*P
-// u = 80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945
-// lambda = 91893752504881257701523279626832445440 (129 bits)
-// s1, s2 are scalars such that s1*lambda+s2 = s
-// s1 on 129 bits
-// s2 on 127 bits
-func (p *G1Jac) ScalarMulEndo(curve *Curve, a *G1Affine, s fr.Element) G1Jac {
-
-	// operation using big int
-	var lambda, _s, _s1, _s2 big.Int
-	lambda.SetString("91893752504881257701523279626832445440", 10)
-	s.ToBigInt(&_s)
-	_s1.DivMod(&_s, &lambda, &_s2)
-	var s1, s2 fr.Element
-	s1.SetBigInt(&_s1).FromMont()
-	s2.SetBigInt(&_s2).FromMont()
-
-	// eigenvalue of phi
-	var thirdRootOne fp.Element
-	thirdRootOne.SetString("80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945")
-
-	// result
-	chDone := make(chan G1Jac, 1)
-
-	// chan monitoring the computation of s1*a and s2*phi(a) respectively
-	chTasks := []chan struct{}{
-		make(chan struct{}),
-		make(chan struct{}),
-	}
-
-	//scalars
-	scalars := []fr.Element{
-		s1,
-		s2,
-	}
-
-	// sizes of s1 and s2
-	sizes := []int{
-		129,
-		127,
-	}
-
-	// a, phi(a)
-	points := []G1Affine{
-		*a,
-		*a,
-	}
-	points[0].X.MulAssign(&thirdRootOne)
-
-	// s1*phi(a), s2*(a)
-	tmpRes := make([]G1Jac, 2)
-
-	// subtask computing a single scalar mul
-	task := func(i int) {
-		tmpRes[i].doubleandadd(curve, &points[i], scalars[i], sizes[i])
-		chTasks[i] <- struct{}{}
-	}
-
-	// wait for each task to be done and add the results
-	reduce := func() {
-		var res G1Jac
-		res.Set(&curve.g1Infinity)
-		<-chTasks[0]
-		res.Add(curve, &tmpRes[0])
-		<-chTasks[1]
-		res.Add(curve, &tmpRes[1])
-		p.Set(&res)
-		chDone <- res
-	}
-
-	go task(0)
-	go task(1)
-	go reduce()
-
-	<-chDone
-
-	return *p
 }
 
 // ScalarMul multiplies a by scalar

--- a/bls377/g1_test.go
+++ b/bls377/g1_test.go
@@ -89,30 +89,30 @@ func TestG1JacDouble(t *testing.T) {
 	}
 }
 
-func TestG1ScalarMulEndo(t *testing.T) {
+// func TestG1ScalarMulEndo(t *testing.T) {
 
-	curve := BLS377()
+// 	curve := BLS377()
 
-	// s = s1*l+s2 where l = 91893752504881257701523279626832445440
-	var s fr.Element
-	s.SetString("8444461749428370424248824930001546531375899335154063827935233455917409239041").FromMont()
+// 	// s = s1*l+s2 where l = 91893752504881257701523279626832445440
+// 	var s fr.Element
+// 	s.SetString("8444461749428370424248824930001546531375899335154063827935233455917409239041").FromMont()
 
-	// correct result
-	var expectedRes G1Jac
-	expectedRes.Set(&curve.g1Gen)
-	expectedRes.ScalarMul(curve, &expectedRes, s)
+// 	// correct result
+// 	var expectedRes G1Jac
+// 	expectedRes.Set(&curve.g1Gen)
+// 	expectedRes.ScalarMul(curve, &expectedRes, s)
 
-	// test
-	var testRes G1Jac
-	var p G1Affine
-	curve.g1Gen.ToAffineFromJac(&p)
-	testRes.ScalarMulEndo(curve, &p, s)
+// 	// test
+// 	var testRes G1Jac
+// 	var p G1Affine
+// 	curve.g1Gen.ToAffineFromJac(&p)
+// 	testRes.ScalarMulEndo(curve, &p, s)
 
-	if !testRes.Equal(&expectedRes) {
-		t.Fatal("scalar Mul endo failed")
-	}
+// 	if !testRes.Equal(&expectedRes) {
+// 		t.Fatal("scalar Mul endo failed")
+// 	}
 
-}
+// }
 
 func TestG1JacScalarMul(t *testing.T) {
 

--- a/bls381/g1.go
+++ b/bls381/g1.go
@@ -37,7 +37,6 @@ limitations under the License.
 // Most algos for points operations are taken from http://hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html
 
 import (
-	"math/big"
 	"runtime"
 
 	"github.com/consensys/gurvy/bls381/fp"
@@ -484,113 +483,6 @@ func (p *G1Jac) Double() *G1Jac {
 	p.Y.SubAssign(&YYYY)
 
 	return p
-}
-
-// queryNthBit returns the i-th bit of s
-func queryNthBit(s fr.Element, i int) uint64 {
-	limb := i / 64
-	offset := i % 64
-	b := (s[limb] >> offset) & 1
-	return b
-}
-
-// doubleandadd algo for exponentiation
-// n=number of bits of the scalar s
-func (p *G1Jac) doubleandadd(curve *Curve, a *G1Affine, s fr.Element, n int) *G1Jac {
-
-	var res G1Jac
-	res.Set(&curve.g1Infinity)
-
-	for i := n - 1; i >= 0; i-- {
-		b := queryNthBit(s, i)
-		res.Double()
-		if b == 1 {
-			res.AddMixed(a)
-		}
-	}
-	p.Set(&res)
-	return &res
-}
-
-// ScalarMulEndo performs scalar multiplication
-// using the endo phi(p=(x,y))=(ux,y) where u is a 3rd root of 1,
-// phi(P) = lambda*P
-// u = 4002409555221667392624310435006688643935503118305586438271171395842971157480381377015405980053539358417135540939436
-// lambda = 228988810152649578064853576960394133503 (128 bits)
-// s1, s2 are scalars such that s1*lambda+s2 = s
-// s1 on 128 bits
-// s2 on 128 bits
-func (p *G1Jac) ScalarMulEndo(curve *Curve, a *G1Affine, s fr.Element) G1Jac {
-
-	// operation using big int
-	var lambda, _s, _s1, _s2 big.Int
-	lambda.SetString("228988810152649578064853576960394133503", 10)
-	s.ToBigInt(&_s)
-	_s1.DivMod(&_s, &lambda, &_s2)
-	var s1, s2 fr.Element
-	s1.SetBigInt(&_s1).FromMont()
-	s2.SetBigInt(&_s2).FromMont()
-
-	// eigenvalue of phi
-	var thirdRootOne fp.Element
-	thirdRootOne.SetString("4002409555221667392624310435006688643935503118305586438271171395842971157480381377015405980053539358417135540939436")
-
-	// result
-	chDone := make(chan G1Jac, 1)
-
-	// chan monitoring the computation of s1*a and s2*phi(a) respectively
-	chTasks := []chan struct{}{
-		make(chan struct{}),
-		make(chan struct{}),
-	}
-
-	//scalars
-	scalars := []fr.Element{
-		s1,
-		s2,
-	}
-
-	// sizes of s1 and s2
-	sizes := []int{
-		128,
-		128,
-	}
-
-	// a, phi(a)
-	points := []G1Affine{
-		*a,
-		*a,
-	}
-	points[0].X.MulAssign(&thirdRootOne)
-
-	// s1*phi(a), s2*(a)
-	tmpRes := make([]G1Jac, 2)
-
-	// subtask computing a single scalar mul
-	task := func(i int) {
-		tmpRes[i].doubleandadd(curve, &points[i], scalars[i], sizes[i])
-		chTasks[i] <- struct{}{}
-	}
-
-	// wait for each task to be done and add the results
-	reduce := func() {
-		var res G1Jac
-		res.Set(&curve.g1Infinity)
-		<-chTasks[0]
-		res.Add(curve, &tmpRes[0])
-		<-chTasks[1]
-		res.Add(curve, &tmpRes[1])
-		p.Set(&res)
-		chDone <- res
-	}
-
-	go task(0)
-	go task(1)
-	go reduce()
-
-	<-chDone
-
-	return *p
 }
 
 // ScalarMul multiplies a by scalar

--- a/bls381/g1_test.go
+++ b/bls381/g1_test.go
@@ -89,29 +89,29 @@ func TestG1JacDouble(t *testing.T) {
 	}
 }
 
-func TestG1ScalarMulEndo(t *testing.T) {
+// func TestG1ScalarMulEndo(t *testing.T) {
 
-	curve := BLS381()
+// 	curve := BLS381()
 
-	var s fr.Element
-	s.SetString("52435875175126190470007740508185965837690552500527637822603658699938581184513").FromMont()
+// 	var s fr.Element
+// 	s.SetString("52435875175126190470007740508185965837690552500527637822603658699938581184513").FromMont()
 
-	// correct result
-	var expectedRes G1Jac
-	expectedRes.Set(&curve.g1Gen)
-	expectedRes.ScalarMul(curve, &expectedRes, s)
+// 	// correct result
+// 	var expectedRes G1Jac
+// 	expectedRes.Set(&curve.g1Gen)
+// 	expectedRes.ScalarMul(curve, &expectedRes, s)
 
-	// test
-	var testRes G1Jac
-	var p G1Affine
-	curve.g1Gen.ToAffineFromJac(&p)
-	testRes.ScalarMulEndo(curve, &p, s)
+// 	// test
+// 	var testRes G1Jac
+// 	var p G1Affine
+// 	curve.g1Gen.ToAffineFromJac(&p)
+// 	testRes.ScalarMulEndo(curve, &p, s)
 
-	if !testRes.Equal(&expectedRes) {
-		t.Fatal("scalar Mul endo failed")
-	}
+// 	if !testRes.Equal(&expectedRes) {
+// 		t.Fatal("scalar Mul endo failed")
+// 	}
 
-}
+// }
 
 func TestG1JacScalarMul(t *testing.T) {
 

--- a/bn256/g1.go
+++ b/bn256/g1.go
@@ -37,7 +37,6 @@ limitations under the License.
 // Most algos for points operations are taken from http://hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html
 
 import (
-	"math/big"
 	"runtime"
 
 	"github.com/consensys/gurvy/bn256/fp"
@@ -484,113 +483,6 @@ func (p *G1Jac) Double() *G1Jac {
 	p.Y.SubAssign(&YYYY)
 
 	return p
-}
-
-// queryNthBit returns the i-th bit of s
-func queryNthBit(s fr.Element, i int) uint64 {
-	limb := i / 64
-	offset := i % 64
-	b := (s[limb] >> offset) & 1
-	return b
-}
-
-// doubleandadd algo for exponentiation
-// n=number of bits of the scalar s
-func (p *G1Jac) doubleandadd(curve *Curve, a *G1Affine, s fr.Element, n int) *G1Jac {
-
-	var res G1Jac
-	res.Set(&curve.g1Infinity)
-
-	for i := n - 1; i >= 0; i-- {
-		b := queryNthBit(s, i)
-		res.Double()
-		if b == 1 {
-			res.AddMixed(a)
-		}
-	}
-	p.Set(&res)
-	return &res
-}
-
-// ScalarMulEndo performs scalar multiplication
-// using the endo phi(p=(x,y))=(ux,y) where u is a 3rd root of 1,
-// phi(P) = lambda*P
-// u = 2203960485148121921418603742825762020974279258880205651966
-// lambda = 4407920970296243842393367215006156084916469457145843978461 (65 bits)
-// s1, s2 are scalars such that s1*lambda+s2 = s
-// s1 on 65 bits
-// s2 on 191 bits
-func (p *G1Jac) ScalarMulEndo(curve *Curve, a *G1Affine, s fr.Element) G1Jac {
-
-	// operation using big int
-	var lambda, _s, _s1, _s2 big.Int
-	lambda.SetString("4407920970296243842393367215006156084916469457145843978461", 10)
-	s.ToBigInt(&_s)
-	_s1.DivMod(&_s, &lambda, &_s2)
-	var s1, s2 fr.Element
-	s1.SetBigInt(&_s1).FromMont()
-	s2.SetBigInt(&_s2).FromMont()
-
-	// eigenvalue of phi
-	var thirdRootOne fp.Element
-	thirdRootOne.SetString("2203960485148121921418603742825762020974279258880205651966")
-
-	// result
-	chDone := make(chan G1Jac, 1)
-
-	// chan monitoring the computation of s1*a and s2*phi(a) respectively
-	chTasks := []chan struct{}{
-		make(chan struct{}),
-		make(chan struct{}),
-	}
-
-	//scalars
-	scalars := []fr.Element{
-		s1,
-		s2,
-	}
-
-	// sizes of s1 and s2
-	sizes := []int{
-		65,
-		191,
-	}
-
-	// a, phi(a)
-	points := []G1Affine{
-		*a,
-		*a,
-	}
-	points[0].X.MulAssign(&thirdRootOne)
-
-	// s1*phi(a), s2*(a)
-	tmpRes := make([]G1Jac, 2)
-
-	// subtask computing a single scalar mul
-	task := func(i int) {
-		tmpRes[i].doubleandadd(curve, &points[i], scalars[i], sizes[i])
-		chTasks[i] <- struct{}{}
-	}
-
-	// wait for each task to be done and add the results
-	reduce := func() {
-		var res G1Jac
-		res.Set(&curve.g1Infinity)
-		<-chTasks[0]
-		res.Add(curve, &tmpRes[0])
-		<-chTasks[1]
-		res.Add(curve, &tmpRes[1])
-		p.Set(&res)
-		chDone <- res
-	}
-
-	go task(0)
-	go task(1)
-	go reduce()
-
-	<-chDone
-
-	return *p
 }
 
 // ScalarMul multiplies a by scalar

--- a/bn256/g1_test.go
+++ b/bn256/g1_test.go
@@ -89,29 +89,29 @@ func TestG1JacDouble(t *testing.T) {
 	}
 }
 
-func TestG1ScalarMulEndo(t *testing.T) {
+// func TestG1ScalarMulEndo(t *testing.T) {
 
-	curve := BN256()
+// 	curve := BN256()
 
-	var s fr.Element
-	s.SetString("21888242071839275222246405745257275088548364400416034343698204106575808495617").FromMont()
+// 	var s fr.Element
+// 	s.SetString("21888242071839275222246405745257275088548364400416034343698204106575808495617").FromMont()
 
-	// correct result
-	var expectedRes G1Jac
-	expectedRes.Set(&curve.g1Gen)
-	expectedRes.ScalarMul(curve, &expectedRes, s)
+// 	// correct result
+// 	var expectedRes G1Jac
+// 	expectedRes.Set(&curve.g1Gen)
+// 	expectedRes.ScalarMul(curve, &expectedRes, s)
 
-	// test
-	var testRes G1Jac
-	var p G1Affine
-	curve.g1Gen.ToAffineFromJac(&p)
-	testRes.ScalarMulEndo(curve, &p, s)
+// 	// test
+// 	var testRes G1Jac
+// 	var p G1Affine
+// 	curve.g1Gen.ToAffineFromJac(&p)
+// 	testRes.ScalarMulEndo(curve, &p, s)
 
-	if !testRes.Equal(&expectedRes) {
-		t.Fatal("scalar Mul endo failed")
-	}
+// 	if !testRes.Equal(&expectedRes) {
+// 		t.Fatal("scalar Mul endo failed")
+// 	}
 
-}
+// }
 
 func TestG1JacScalarMul(t *testing.T) {
 
@@ -308,20 +308,20 @@ func BenchmarkMultiExpG1(b *testing.B) {
 	}
 }
 
-func BenchmarkEndo(b *testing.B) {
-	curve := BN256()
+// func BenchmarkEndo(b *testing.B) {
+// 	curve := BN256()
 
-	var s fr.Element
-	s.SetString("21888242071839275222246405745257275088548364400416034343698204106575808495617").FromMont()
+// 	var s fr.Element
+// 	s.SetString("21888242071839275222246405745257275088548364400416034343698204106575808495617").FromMont()
 
-	// test
-	var testRes G1Jac
-	var p G1Affine
-	curve.g1Gen.ToAffineFromJac(&p)
+// 	// test
+// 	var testRes G1Jac
+// 	var p G1Affine
+// 	curve.g1Gen.ToAffineFromJac(&p)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		testRes.ScalarMulEndo(curve, &p, s)
-	}
+// 	b.ResetTimer()
+// 	for i := 0; i < b.N; i++ {
+// 		testRes.ScalarMulEndo(curve, &p, s)
+// 	}
 
-}
+// }

--- a/internal/generators/template/generator/generator.go
+++ b/internal/generators/template/generator/generator.go
@@ -160,7 +160,7 @@ func GenerateCurve(d GenerateData) error {
 			gpoint.Add,
 			gpoint.AddMixed,
 			gpoint.Double,
-			gpoint.EndoMul,
+			// gpoint.EndoMul,
 			gpoint.ScalarMul,
 			gpoint.WindowedMultiExp,
 			gpoint.MultiExp,


### PR DESCRIPTION
We recently became aware that GLV point multiplication is encumbered by patent.  This PR removes support for GLV point multiplication so as not to infringe upon the patent.  The patent has expired everywhere except in the USA, where it is set to expire in September 2020.  We can re-enable support for GLV point multiplication after the patent has expired everywhere.