### PR TITLE
replace k/2-th Frobenius powers by conjugations

### DIFF
--- a/bls377/pairing.go
+++ b/bls377/pairing.go
@@ -49,8 +49,7 @@ func (z *GT) FinalExponentiation(x *GT) *GT {
 	var t [6]GT
 
 	// easy part
-	t[0].FrobeniusCube(&result).
-		FrobeniusCube(&t[0])
+	t[0].InverseUnitary(&result)
 	result.Inverse(&result)
 	t[0].Mul(&t[0], &result)
 	result.FrobeniusSquare(&t[0]).

--- a/bls377/pairing.go
+++ b/bls377/pairing.go
@@ -49,7 +49,7 @@ func (z *GT) FinalExponentiation(x *GT) *GT {
 	var t [6]GT
 
 	// easy part
-	t[0].InverseUnitary(&result)
+	t[0].Conjugate(&result)
 	result.Inverse(&result)
 	t[0].Mul(&t[0], &result)
 	result.FrobeniusSquare(&t[0]).

--- a/bls381/pairing.go
+++ b/bls381/pairing.go
@@ -52,8 +52,7 @@ func (z *GT) FinalExponentiation(x *GT) *GT {
 	var t [6]GT
 
 	// easy part
-	t[0].FrobeniusCube(&result).
-		FrobeniusCube(&t[0])
+	t[0].InverseUnitary(&result)
 	result.Inverse(&result)
 	t[0].Mul(&t[0], &result)
 	result.FrobeniusSquare(&t[0]).

--- a/bls381/pairing.go
+++ b/bls381/pairing.go
@@ -52,7 +52,7 @@ func (z *GT) FinalExponentiation(x *GT) *GT {
 	var t [6]GT
 
 	// easy part
-	t[0].InverseUnitary(&result)
+	t[0].Conjugate(&result)
 	result.Inverse(&result)
 	t[0].Mul(&t[0], &result)
 	result.FrobeniusSquare(&t[0]).

--- a/bn256/pairing.go
+++ b/bn256/pairing.go
@@ -49,7 +49,7 @@ func (z *GT) FinalExponentiation(x *GT) *GT {
 	// easy part
 	mt[0].Set(x)
 	var temp GT
-	temp.InverseUnitary(&mt[0])
+	temp.Conjugate(&mt[0])
 	mt[0].Inverse(&mt[0])
 	temp.Mul(&temp, &mt[0])
 	mt[0].FrobeniusSquare(&temp).

--- a/bn256/pairing.go
+++ b/bn256/pairing.go
@@ -49,8 +49,7 @@ func (z *GT) FinalExponentiation(x *GT) *GT {
 	// easy part
 	mt[0].Set(x)
 	var temp GT
-	temp.FrobeniusCube(&mt[0]).
-		FrobeniusCube(&temp)
+	temp.InverseUnitary(&mt[0])
 	mt[0].Inverse(&mt[0])
 	temp.Mul(&temp, &mt[0])
 	mt[0].FrobeniusSquare(&temp).


### PR DESCRIPTION
Issue: #13 
Replace 6-th Frobenius power by unitary inverse in BN254, BLS12-377 and BLS12-381

**TODO**
Same goes for BW6-761 especially that it uses many `FrobeniusCube` in the hard part, but it seems that BW6 `GT`is implemented as `Fp3over2` rather than `Fp2over3`.
