### PR TITLE
Optimize BLS12-381 final exponentiation

### DIFF
--- a/bls381/internal/fptower/e12_pairing.go
+++ b/bls381/internal/fptower/e12_pairing.go
@@ -62,9 +62,9 @@ func (z *E12) nSquare(n int) {
 	}
 }
 
-// Expt set z to x^t in E12 and return z
-// const t uint64 = 15132376222941642752 // negative
-func (z *E12) Expt(x *E12) *E12 {
+// Expt set z to x^(t/2) in E12 and return z
+// const t/2 uint64 = 7566188111470821376 // negative
+func (z *E12) ExptHalf(x *E12) *E12 {
 	var result E12
 	result.CyclotomicSquare(x)
 	result.Mul(&result, x)
@@ -76,6 +76,14 @@ func (z *E12) Expt(x *E12) *E12 {
 	result.Mul(&result, x)
 	result.nSquare(32)
 	result.Mul(&result, x)
-	result.nSquare(16)
+	result.nSquare(15)
 	return z.Conjugate(&result) // because tAbsVal is negative
+}
+
+// Expt set z to x^t in E12 and return z
+// const t uint64 = 15132376222941642752 // negative
+func (z *E12) Expt(x *E12) *E12 {
+	var result E12
+	result.ExptHalf(x)
+	return z.CyclotomicSquare(&result)
 }

--- a/bls381/pairing.go
+++ b/bls381/pairing.go
@@ -51,36 +51,30 @@ func FinalExponentiation(z *GT, _z ...*GT) GT {
 		Mul(&result, &t[0])
 
 	// hard part (up to permutation)
-	t[0].InverseUnitary(&result).CyclotomicSquare(&t[0])
-	t[5].Expt(&result)
-	t[1].CyclotomicSquare(&t[5])
-	t[3].Mul(&t[0], &t[5])
-
-	t[0].Expt(&t[3])
-	t[2].Expt(&t[0])
-	t[4].Expt(&t[2])
-
-	t[4].Mul(&t[1], &t[4])
-	t[1].Expt(&t[4])
-	t[3].InverseUnitary(&t[3])
-	t[1].Mul(&t[3], &t[1])
-	t[1].Mul(&t[1], &result)
-
-	t[0].Mul(&t[0], &result)
-	t[0].FrobeniusCube(&t[0])
-
+	// Alg.2 from https://eprint.iacr.org/2016/130.pdf
+	t[0].CyclotomicSquare(&result)
+	t[1].Expt(&t[0])
+	t[2].ExptHalf(&t[1])
 	t[3].InverseUnitary(&result)
-	t[4].Mul(&t[3], &t[4])
-	t[4].Frobenius(&t[4])
+	t[1].Mul(&t[1], &t[3])
+	t[1].InverseUnitary(&t[1])
+	t[1].Mul(&t[1], &t[2])
+	t[2].Expt(&t[1])
+	t[3].Expt(&t[2])
+	t[1].InverseUnitary(&t[1])
+	t[3].Mul(&t[1], &t[3])
+	t[1].InverseUnitary(&t[1])
+	t[1].FrobeniusCube(&t[1])
+	t[2].FrobeniusSquare(&t[2])
+	t[1].Mul(&t[1], &t[2])
+	t[2].Expt(&t[3])
+	t[2].Mul(&t[2], &t[0])
+	t[2].Mul(&t[2], &result)
+	t[1].Mul(&t[1], &t[2])
+	t[2].Frobenius(&t[3])
+	t[1].Mul(&t[1], &t[2])
 
-	t[5].Mul(&t[2], &t[5])
-	t[5].FrobeniusSquare(&t[5])
-
-	t[5].Mul(&t[5], &t[0])
-	t[5].Mul(&t[5], &t[4])
-	t[5].Mul(&t[5], &t[1])
-
-	result.Set(&t[5])
+	result.Set(&t[1])
 
 	return result
 }


### PR DESCRIPTION
Since the `bls12-381` seed is even, this PR implements Alg.2 from https://eprint.iacr.org/2016/130.pdf. 
This saves 2 multiplications and 2 squares in `Fq12`, and 2 temporary variables. 
According to `BenchmarkFinalExponentiation`, this saves around `127336 ns/op`.