### PR TITLE
Pairing: remove preCompute and go routines in MillerLoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ These benchmarks ran on a AWS z1d.3xlarge instance, with hyperthreading disabled
 |G2::ScalarMul|	88423|	141000|
 |G2::Add	|598|	871|
 |G2::Double	|371|	386|
-|Pairing	|478244	|606000|
+|Pairing	|478244	|489258|
 
 
 ----
@@ -80,7 +80,7 @@ These benchmarks ran on a AWS z1d.3xlarge instance, with hyperthreading disabled
 |G2::ScalarMul|	159068|	273000|
 |G2::Add	|1162|	1240|
 |G2::Double	|727|	799|
-|Pairing	|676513	|949000|
+|Pairing	|676513	|707984|
 
 *note that some routines don't have assembly implementation in `goff` yet.
 

--- a/bn256/pairing.go
+++ b/bn256/pairing.go
@@ -159,14 +159,24 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 
 		for k := 0; k < n; k++ {
 			qProj[k].DoubleStep(&l)
-			lineEval(&result, &l, &p[k])
+			// line evaluation
+			l.r0.MulByElement(&l.r0, &p[k].Y)
+			l.r1.MulByElement(&l.r1, &p[k].X)
+			result.MulBy034(&l.r0, &l.r1, &l.r2)
 
 			if loopCounter[i] == 1 {
 				qProj[k].AddMixedStep(&l, &q[k])
-				lineEval(&result, &l, &p[k])
+				// line evaluation
+				l.r0.MulByElement(&l.r0, &p[k].Y)
+				l.r1.MulByElement(&l.r1, &p[k].X)
+				result.MulBy034(&l.r0, &l.r1, &l.r2)
+
 			} else if loopCounter[i] == -1 {
 				qProj[k].AddMixedStep(&l, &qNeg[k])
-				lineEval(&result, &l, &p[k])
+				// line evaluation
+				l.r0.MulByElement(&l.r0, &p[k].Y)
+				l.r1.MulByElement(&l.r1, &p[k].X)
+				result.MulBy034(&l.r0, &l.r1, &l.r2)
 			}
 		}
 	}
@@ -183,21 +193,19 @@ func MillerLoop(P []G1Affine, Q []G2Affine) (GT, error) {
 		Q2.Y.MulByNonResidue2Power3(&q[k].Y).Neg(&Q2.Y)
 
 		qProj[k].AddMixedStep(&l, &Q1)
-		lineEval(&result, &l, &p[k])
+		// line evaluation
+		l.r0.MulByElement(&l.r0, &p[k].Y)
+		l.r1.MulByElement(&l.r1, &p[k].X)
+		result.MulBy034(&l.r0, &l.r1, &l.r2)
+
 		qProj[k].AddMixedStep(&l, &Q2)
-		lineEval(&result, &l, &p[k])
+		// line evaluation
+		l.r0.MulByElement(&l.r0, &p[k].Y)
+		l.r1.MulByElement(&l.r1, &p[k].X)
+		result.MulBy034(&l.r0, &l.r1, &l.r2)
 	}
 
 	return result, nil
-}
-
-func lineEval(result *GT, l *lineEvaluation, P *G1Affine) *GT {
-
-	l.r0.MulByElement(&l.r0, &P.Y)
-	l.r1.MulByElement(&l.r1, &P.X)
-	result.MulBy034(&l.r0, &l.r1, &l.r2)
-
-	return result
 }
 
 // DoubleStep doubles a point in Homogenous projective coordinates, and evaluates the line in Miller loop


### PR DESCRIPTION
@yelhousni following your recent awesome PR (#26) did some experiments and benchmarks on various architectures (x64), that confirms that for a small number of pair of points in the `Pairing` function, there is a severe penalty (specifically on `amd` platforms). 

In this PR, I just removed the go routines, the multiple `[68]lineEvaluation` (replace by a single `lineEvaluation` object) and merged the `preCompute` loop within the line evaluation / result compute loop. Did on `bn256` and `bls381`.

** If we want to deal with large number of pairs in `Pairing`, then we should probably revisit the `preCompute` strategy ** 

Here is where we're at on our reference benchmark (running on AWS z1d.3xlarge instance, with hyperthreading disabled) :

 ||mcl(ns/op)|gurvy(ns/op)|
| -------- | -------- | -------- |
|Pairing(bn256)	|478244	|489258|
|Pairing(bls381)	|676513	|707984|

For the before/after removal of go routines and precompute:

on AMD Ryzen 3700X, bn256 and bls381:
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkPairing-16        717847        429341        -40.19%
BenchmarkMillerLoop-16     330055        209102        -36.65%
```
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkPairing-16        1156689       644036        -44.32%
BenchmarkMillerLoop-16     517074        308647        -40.31%
```

on Intel MBP, less conclusive but not too bad:
```
benchmark                 old ns/op     new ns/op     delta
BenchmarkPairing-8        561681        546137        -2.77%
BenchmarkMillerLoop-8     253963        263012        +3.56%
```
